### PR TITLE
Fix for running on windows

### DIFF
--- a/lib/omni-binaries.js
+++ b/lib/omni-binaries.js
@@ -1,6 +1,6 @@
 var fs= require('fs')
     , path = require('path')
-    , serverPath = path.resolve(__dirname, './server/omnisharp');
+    , serverPath = path.resolve(__dirname, './server/' + (process.platform === 'win32' ? 'omnisharp.cmd' : 'omnisharp'));
 
 module.exports = serverPath;
 


### PR DESCRIPTION
Calls omnisharp.cmd if on win32  (would be good to verify this doesn't impact other platforms).