### PR TITLE
add ability to use a diff roslyn server by setting OMNISHARP env variable

### DIFF
--- a/lib/omni-binaries.js
+++ b/lib/omni-binaries.js
@@ -1,6 +1,5 @@
 var fs= require('fs')
     , path = require('path')
-    , serverPath = path.resolve(__dirname, './server/' + (process.platform === 'win32' ? 'omnisharp.cmd' : 'omnisharp'));
+    , serverPath = process.env['OMNISHARP'] || path.resolve(__dirname, './server/' + (process.platform === 'win32' ? 'omnisharp.cmd' : 'omnisharp'));
 
 module.exports = serverPath;
-


### PR DESCRIPTION
should then work the same as in brackets

https://github.com/OmniSharp/omnisharp-brackets/blob/master/node/omnisharp.js#L91